### PR TITLE
Fix the latest ruff cmd error

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,9 +23,9 @@ jobs:
       - name: Lint with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          ruff --format=github --select=E9,F63,F7,F82 --target-version=py37 .
+          ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py37 .
           # default set of ruff rules with GitHub Annotations
-          ruff --format=github --target-version=py37 .
+          ruff check --output-format=github --target-version=py37 .
       - name: Test with pytest
         run: |
           pytest


### PR DESCRIPTION
Use the latest and greatest ruff check format e.g.
```
ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py37 .
```